### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,3 @@
+language = "nodejs"
+  run = "npm start"
+  

--- a/README.md
+++ b/README.md
@@ -52,3 +52,5 @@ For instance if you type a message with `@user` in your guild but this user is n
 To start the bot once everything is ready, you can do: 
   - `npm start` or `yarn start` to run the bot normally.
   - `npm pm2start` or `yarn pm2start` to run the bot with pm2.
+
+[![Run on Repl.it](https://repl.it/badge/github/Khaazz/Cross-Server-Bot)](https://repl.it/github/Khaazz/Cross-Server-Bot)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).